### PR TITLE
fix(fonts): make fonts be picked up by home-manager

### DIFF
--- a/casks.nix
+++ b/casks.nix
@@ -151,6 +151,16 @@ let
       installPhase = ''
         pwd
         ls -la
+        for app in ./*.app; do
+          mkdir -p "$out/Applications/${sourceRoot}"
+          cp -R "$app" "$out/Applications/${sourceRoot}/"
+        done
+
+        if [ -d "Contents" ]; then
+          echo "CONTENTS"
+          mkdir -p "$out/Applications/${sourceRoot}"
+          cp -R . "$out/Applications/${sourceRoot}/"
+        fi
         ${
           if (hasPkg cask) then
             ''
@@ -179,10 +189,8 @@ let
         }
         ${
           if (hasApp cask) then
+            # TODO: assert the .app exists
             ''
-              mkdir -p "$out/Applications/${sourceRoot}"
-              cp -R . "$out/Applications/${sourceRoot}"
-
               if [[ -e "$out/Applications/${sourceRoot}/Contents/MacOS/${getName cask}" ]]; then
                 makeWrapper "$out/Applications/${sourceRoot}/Contents/MacOS/${getName cask}" $out/bin/${cask.token}
               elif [[ -e "$out/Applications/${sourceRoot}/Contents/MacOS/${lib.removeSuffix ".app" sourceRoot}" ]]; then
@@ -194,6 +202,7 @@ let
         }
         ${
           if (hasBinary cask && !hasApp cask) then
+            # TODO: get the name of the binary and only copy that
             ''
               mkdir -p $out/bin
               cp -R "./*" "$out/bin"

--- a/casks.nix
+++ b/casks.nix
@@ -168,6 +168,11 @@ let
                 mkdir -p "$out/Library"
                 cp -R Library/* "$out/Library/"
               fi
+
+              if [ -d "$out/Library/Fonts" ]; then
+                mkdir -p "$out/share/fonts"
+                cp -R $out/Library/Fonts/* $out/share/fonts
+              fi
             ''
           else
             ''''


### PR DESCRIPTION
The whole `Library` and `Resources` folder should already be handled by home-manager imo, but IDK how that should happen.